### PR TITLE
False negative: selector exprs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "mode": "debug",
             "program": "main.go",
             "args": [
-                "testdata/bad.go"
+                "testdata/capture_mistake.go"
             ]
         }
     ]

--- a/ifacecapture/captured_call.go
+++ b/ifacecapture/captured_call.go
@@ -1,0 +1,45 @@
+package ifacecapture
+
+import "go/ast"
+
+// CallViaReceiver represents a call to a function on a receiver, possibly
+// through a chain of Selector expressions.
+type CallViaReceiver struct {
+	// The chain of Selector expressions that lead to the function. E.g. in
+	// a.b.c.foo(), the selectors are [a, b, c].
+	Chain []*ast.Ident
+}
+
+func NewCallViaReceiver() CallViaReceiver {
+	return CallViaReceiver{
+		Chain: []*ast.Ident{},
+	}
+}
+
+// ProcessSelExpr recursively processes a SelectorExpr and adds the chain of
+// Idents to the .Chain field.
+func (c *CallViaReceiver) ProcessSelExpr(expr *ast.SelectorExpr) {
+	if ident, ok := expr.X.(*ast.Ident); ok {
+		c.Chain = append(c.Chain, ident)
+	} else if expr.X.(*ast.SelectorExpr) != nil {
+		c.ProcessSelExpr(expr.X.(*ast.SelectorExpr))
+		c.Chain = append(c.Chain, expr.X.(*ast.SelectorExpr).Sel)
+	}
+}
+
+func (c CallViaReceiver) Receiver() *ast.Ident {
+	// last of the chain
+	return c.Chain[len(c.Chain)-1]
+}
+
+// Formats the CallViaReceiver as a string in the form "a.b.c"
+func (c CallViaReceiver) String() string {
+	selChainString := ""
+	sep := ""
+	for _, sel := range c.Chain {
+		selChainString += sep + sel.Name
+		sep = "."
+	}
+
+	return selChainString
+}

--- a/ifacecapture/ifacecapture.go
+++ b/ifacecapture/ifacecapture.go
@@ -3,6 +3,7 @@ package ifacecapture
 import (
 	"go/ast"
 	"go/types"
+	"log"
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
@@ -57,24 +58,30 @@ func FindPossiblyUnintentionalInterfaceCaptures(pass *analysis.Pass) (any, error
 		}
 
 		// Step 5: gather all captured variables in the body
+		// Get all CallExprs with receivers
 		var capturedVariables []*ast.Ident
 		ast.Inspect(callback.Body, func(node ast.Node) bool {
 			switch node.(type) {
-			case *ast.Ident:
-				// Is it a variable?
-				ident := node.(*ast.Ident)
-				if ident.Obj != nil && ident.Obj.Kind == ast.Var {
-					// Was this declared outside the callback?
-					if ident.Obj.Decl != nil {
-						switch ident.Obj.Decl.(type) {
-						case *ast.Field, *ast.AssignStmt:
-							declPos := ident.Obj.Decl.(ast.Node).Pos()
-							if declPos < callback.Pos() {
-								capturedVariables = append(capturedVariables, ident)
-							}
-						}
-					}
-				}
+			case *ast.CallExpr:
+				callExpr := node.(*ast.CallExpr)
+				log.Printf("callExpr: %+v", callExpr)
+
+				// Does the
+				// case *ast.Ident:
+				// 	// Is it a variable?
+				// 	ident := node.(*ast.Ident)
+				// 	if ident.Obj != nil && ident.Obj.Kind == ast.Var {
+				// 		// Was this declared outside the callback?
+				// 		if ident.Obj.Decl != nil {
+				// 			switch ident.Obj.Decl.(type) {
+				// 			case *ast.Field, *ast.AssignStmt:
+				// 				declPos := ident.Obj.Decl.(ast.Node).Pos()
+				// 				if declPos < callback.Pos() {
+				// 					capturedVariables = append(capturedVariables, ident)
+				// 				}
+				// 			}
+				// 		}
+				// 	}
 			}
 			return true
 		})

--- a/ifacecapture/ifacecapture.go
+++ b/ifacecapture/ifacecapture.go
@@ -58,7 +58,6 @@ func FindPossiblyUnintentionalInterfaceCaptures(pass *analysis.Pass) (any, error
 
 		// Step 5: gather all captured variables in the body
 		// Get all CallExprs with receivers
-
 		capturedCalls := []CallViaReceiver{}
 		ast.Inspect(callback.Body, func(node ast.Node) bool {
 			switch node.(type) {
@@ -74,7 +73,6 @@ func FindPossiblyUnintentionalInterfaceCaptures(pass *analysis.Pass) (any, error
 			return true
 		})
 
-		// TODO: uncomment
 		// Do any of them implement interfaces in the param list?
 		for _, capturedCall := range capturedCalls {
 			capturedType := pass.TypesInfo.TypeOf(capturedCall.Receiver())

--- a/testdata/capture_mistake.go
+++ b/testdata/capture_mistake.go
@@ -25,9 +25,11 @@ type HasMyImpl struct {
 func main() {
 	outer := MyImpl{}
 	outer2 := HasMyImpl{A: MyImpl{}}
+	outer3 := struct{ B HasMyImpl }{B: HasMyImpl{A: MyImpl{}}}
 	doThing(func(inner MyInterface) {
-		outer.Do()    // want "captured variable outer implements interface MyInterface"
-		outer2.A.Do() // want "captured variable outer2.A implements interface MyInterface"
+		outer.Do()      // want "captured variable outer implements interface MyInterface"
+		outer2.A.Do()   // want "captured variable outer2.A implements interface MyInterface"
+		outer3.B.A.Do() // want "captured variable outer3.B.A implements interface MyInterface"
 		inner.Do()
 	})
 }

--- a/testdata/capture_mistake.go
+++ b/testdata/capture_mistake.go
@@ -18,10 +18,16 @@ func doThing(callback func(tx MyInterface)) {
 	callback(&myImpl)
 }
 
+type HasMyImpl struct {
+	A MyImpl
+}
+
 func main() {
 	outer := MyImpl{}
+	outer2 := HasMyImpl{A: MyImpl{}}
 	doThing(func(inner MyInterface) {
-		outer.Do() // want "captured variable outer implements interface MyInterface"
+		outer.Do()    // want "captured variable outer implements interface MyInterface"
+		outer2.A.Do() // want "captured variable outer2.A implements interface MyInterface"
 		inner.Do()
 	})
 }


### PR DESCRIPTION
Catches usage of captured variables that are at the end of selector expressions, like `A.B.Foo()`, where B implements an interface we are checking against.