### PR TITLE
Detect captured receiver is same concrete type as a parameter.

### DIFF
--- a/ifacecapture/ifacecapture.go
+++ b/ifacecapture/ifacecapture.go
@@ -48,10 +48,16 @@ var (
 	InterfacesAllowList arrayFlags = arrayFlags{}
 )
 
-type ParamType struct {
+type InterfaceParamType struct {
 	Vars           []*ast.Ident
 	InterfaceIdent *ast.Ident
 	InterfaceType  *types.Interface
+}
+
+type ConcreteParamType struct {
+	Vars  []*ast.Ident
+	Ident *ast.Ident
+	Type  types.Type
 }
 
 func run(pass *analysis.Pass) (any, error) {
@@ -83,15 +89,20 @@ func run(pass *analysis.Pass) (any, error) {
 
 		logger.Debugf("Examining function %s with callback", renderSafe(pass.Fset, callExpr.Fun))
 
-		// Step 4: gather all interface types in the param list
-
-		var paramInterfaceTypes []ParamType
+		// Step 4: gather all types in the param list
+		var paramInterfaceTypes []InterfaceParamType
+		var paramConcreteTypes []ConcreteParamType
 		for _, param := range callback.Type.Params.List {
 			if param.Type != nil {
 				vars := param.Names
 
 				paramType := pass.TypesInfo.TypeOf(param.Type)
-				if _, ok := paramType.Underlying().(*types.Interface); ok {
+				underlying := paramType.Underlying()
+				if IsPointerType(underlying) {
+					underlying = underlying.(*types.Pointer).Elem()
+				}
+				switch paramType := underlying.(type) {
+				case *types.Interface, *types.Named:
 					// May have to go forward all the way to get the ident
 					chain := NewTypeChain()
 					if err := chain.ProcessTypeChain(param.Type); err != nil {
@@ -99,20 +110,29 @@ func run(pass *analysis.Pass) (any, error) {
 						continue
 					}
 
-					paramInterfaceTypes = append(paramInterfaceTypes, ParamType{
-						InterfaceIdent: chain.Last(),
-						InterfaceType:  paramType.Underlying().(*types.Interface),
-						Vars:           vars,
-					})
+					if _, ok := paramType.(*types.Interface); ok {
+						paramInterfaceTypes = append(paramInterfaceTypes, InterfaceParamType{
+							InterfaceIdent: chain.Last(),
+							InterfaceType:  paramType.Underlying().(*types.Interface),
+							Vars:           vars,
+						})
+					} else {
+						paramConcreteTypes = append(paramConcreteTypes, ConcreteParamType{
+							Ident: chain.Last(),
+							Type:  paramType,
+							Vars:  vars,
+						})
+					}
 				}
 			}
 		}
 
-		if len(paramInterfaceTypes) == 0 {
-			logger.Debug("No interfaces found in param list")
+		if len(paramInterfaceTypes) == 0 && len(paramConcreteTypes) == 0 {
+			logger.Debug("No interfaces or concrete types found in param list")
 			return true
 		}
 		logger.Debugf("Found interfaces %v in param list of %s", paramInterfaceTypes, renderSafe(pass.Fset, callback.Type))
+		logger.Debugf("Found concrete types %v in param list of %s", paramConcreteTypes, renderSafe(pass.Fset, callback.Type))
 
 		// Step 5: gather all captured variables in the body
 		// Get all CallExprs with receivers
@@ -136,6 +156,7 @@ func run(pass *analysis.Pass) (any, error) {
 		})
 
 		// Do any of them implement interfaces in the param list?
+		// Do any of them match the concrete types in the param list?
 		for _, capturedCall := range capturedCalls {
 			capturedType := capturedCall.ReceivedByType
 			logger.Debugf("Examining captured type %v", capturedType)
@@ -156,15 +177,29 @@ func run(pass *analysis.Pass) (any, error) {
 				ifaceType := paramType.InterfaceType
 				logger.Debugf("Checking if %s implements %s", capturedType, paramType.InterfaceIdent.Name)
 				if types.Implements(capturedType, ifaceType) {
-					Report(pass, &capturedCall, paramType)
+					ReportInterface(pass, &capturedCall, paramType)
 				} else if types.Implements(types.NewPointer(capturedType), ifaceType) {
 					// FIXME: it is unclear to me why sometimes it is necessary
 					// to convert the type to a pointer before checking if it
 					// implements the interface. Haven't yet reproduced the bug.
-					Report(pass, &capturedCall, paramType)
+					ReportInterface(pass, &capturedCall, paramType)
+				}
+			}
+
+			for _, paramType := range paramConcreteTypes {
+				// Don't check if the receiver is one of the function params
+				if util.Any(paramType.Vars, func(paramVar *ast.Ident) bool {
+					return capturedCall.Receiver().Obj == paramVar.Obj
+				}) {
+					logger.Debugf("Skipping captured type %v because it is a param", capturedType)
+					continue
 				}
 
+				if paramType.Type == capturedType {
+					ReportConcrete(pass, &capturedCall, paramType)
+				}
 			}
+
 		}
 
 		return false
@@ -178,18 +213,30 @@ func run(pass *analysis.Pass) (any, error) {
 	return nil, nil
 }
 
-func Report(pass *analysis.Pass, call *CallViaReceiver, paramType ParamType) {
-	identPackage := pass.TypesInfo.ObjectOf(paramType.InterfaceIdent).Pkg()
+func ReportInterface(pass *analysis.Pass, call *CallViaReceiver, iParamType InterfaceParamType) {
+	identPackage := pass.TypesInfo.ObjectOf(iParamType.InterfaceIdent).Pkg()
 	identString := ""
 	if pass.Pkg != identPackage {
 		identString = fmt.Sprintf("%s.", identPackage.Name())
 	}
-	identString += paramType.InterfaceIdent.Name
+	identString += iParamType.InterfaceIdent.Name
 
 	pass.Reportf(
 		call.Receiver().Pos(),
 		"captured variable %s implements interface %s",
 		call.String(), identString,
+	)
+}
+
+// ReportConcrete reports that the receiver of `capturedCall` is the same concrete
+// type as the type of `paramType`.
+func ReportConcrete(pass *analysis.Pass, capturedCall *CallViaReceiver, paramType ConcreteParamType) {
+	identString := paramType.Vars[0].Name
+
+	pass.Reportf(
+		capturedCall.Receiver().Pos(),
+		"captured variable %s is of same type as parameter %s",
+		capturedCall.String(), identString,
 	)
 }
 

--- a/ifacecapture/ifacecapture_test.go
+++ b/ifacecapture/ifacecapture_test.go
@@ -15,6 +15,8 @@ func TestAll(t *testing.T) {
 		t.Fatalf("Failed to get wd: %s", err)
 	}
 
+	ifacecapture.Loglvl = "debug"
+
 	testdata := filepath.Join(filepath.Dir(wd), "testdata")
 	analysistest.Run(t, testdata, ifacecapture.Analyzer, "./src/...")
 }

--- a/ifacecapture/type_chain.go
+++ b/ifacecapture/type_chain.go
@@ -18,13 +18,12 @@ func NewTypeChain() TypeChain {
 }
 
 func (t *TypeChain) ProcessTypeChain(expr ast.Expr) error {
-	switch expr.(type) {
+	switch expr := expr.(type) {
 	case *ast.Ident:
-		t.Types = append(t.Types, expr.(*ast.Ident))
+		t.Types = append(t.Types, expr)
 	case *ast.SelectorExpr:
-		selExpr := expr.(*ast.SelectorExpr)
 		idents := []*ast.Ident{}
-		err := traverseSelChain(&idents, selExpr)
+		err := traverseSelChain(&idents, expr)
 		if err != nil {
 			return err
 		}
@@ -35,6 +34,8 @@ func (t *TypeChain) ProcessTypeChain(expr ast.Expr) error {
 		}
 
 		t.Types = append(t.Types, idents...)
+	case *ast.StarExpr:
+		return t.ProcessTypeChain(expr.X)
 	}
 
 	return nil

--- a/testdata/src/concrete/concrete_param.go
+++ b/testdata/src/concrete/concrete_param.go
@@ -1,0 +1,36 @@
+// Example program that erroneously captures the outer variable when it likely
+// intends to use the parameter.
+
+package main
+
+type MyImpl struct{}
+
+func (m *MyImpl) Do() {}
+
+func doThing(callback func(tx *MyImpl)) {
+	myImpl := MyImpl{}
+	callback(&myImpl)
+}
+
+type HasMyImpl struct {
+	A MyImpl
+}
+
+func (h HasMyImpl) GetMyImpl() *MyImpl {
+	return &h.A
+}
+
+func main() {
+	outer := MyImpl{}
+	outer2 := HasMyImpl{A: MyImpl{}}
+	outer3 := struct{ B HasMyImpl }{B: HasMyImpl{A: MyImpl{}}}
+	outerArr := [2]MyImpl{{}, {}}
+	doThing(func(inner *MyImpl) {
+		outer.Do()              // want "captured variable outer is of same type as parameter inner"
+		outer2.A.Do()           // want "captured variable outer2.A is of same type as parameter inner"
+		outer3.B.A.Do()         // want "captured variable outer3.B.A is of same type as parameter inner"
+		outerArr[0].Do()        // We don't flag this yet because it is a lot of extra work
+		outer2.GetMyImpl().Do() // We don't flag this yet because it becomes much harder to analyze where the receiver is coming from
+		inner.Do()
+	})
+}


### PR DESCRIPTION
This fixes one of the issues brought up by @farhaven in #4 